### PR TITLE
Add missing arguments compiler_flags and excluded_paths

### DIFF
--- a/automatic_tool_installation.py
+++ b/automatic_tool_installation.py
@@ -63,7 +63,7 @@ def handle_kwstyle_download():
 
     kwstyle_dir = os.path.join(softwipe_dir, 'KWStyle')
     print('Building KWStyle...')
-    compile_phase.compile_program_cmake(kwstyle_dir, 1, dont_check_for_warnings=True)  # The argument
+    compile_phase.compile_program_cmake(kwstyle_dir, 1, dont_check_for_warnings=True, compiler_flags="", excluded_paths="")  # The argument
     # lines_of_code (2nd arg) does not matter here
     print('Done!')
     print()


### PR DESCRIPTION
Thanks for the great tool. I stumble over two missing arguments `compiler_flags` and `excluded_paths` in compile_phase.compile_program_cmake during the build of KWStyle.

The error message was
```
Building KWStyle...
Traceback (most recent call last):
  File "./softwipe.py", line 296, in <module>
    main()
  File "./softwipe.py", line 263, in main
    automatic_tool_installation.check_if_all_required_tools_are_installed()
  File "/home/user/softwipe/automatic_tool_installation.py", line 146, in check_if_all_required_tools_are_installed
    auto_install_prompt(missing_tools, package_install_command)
  File "/home/user/softwipe/automatic_tool_installation.py", line 118, in auto_install_prompt
    auto_tool_install(missing_tools, package_install_command)
  File "/home/user/softwipe/automatic_tool_installation.py", line 102, in auto_tool_install
    handle_tool_download(tool.install_name)
  File "/home/user/softwipe/automatic_tool_installation.py", line 78, in handle_tool_download
    handle_kwstyle_download()
  File "/home/user/softwipe/automatic_tool_installation.py", line 66, in handle_kwstyle_download
    compile_phase.compile_program_cmake(kwstyle_dir, 1, dont_check_for_warnings=True)  # The argument
TypeError: compile_program_cmake() missing 2 required positional arguments: 'compiler_flags' and 'excluded_paths'
```