### PR TITLE
Replaces `platform.linux_distribution()` with `distro.linux_distribut…

### DIFF
--- a/automatic_tool_installation.py
+++ b/automatic_tool_installation.py
@@ -5,6 +5,7 @@ Functions related to the automatic installation of dependencies.
 import inspect
 import os
 import platform
+import distro
 import shutil
 import subprocess
 import sys
@@ -22,8 +23,8 @@ def detect_user_os():
     """
     system = platform.system()
     if system == 'Linux':
-        distro = platform.linux_distribution()
-        detected_os = distro[0]
+        detected_distro = distro.linux_distribution(full_distribution_name=False)
+        detected_os = detected_distro[0]
     else:
         detected_os = system
     return detected_os


### PR DESCRIPTION
…ion`

Python 3.8 removes the function `platform.linux_distibution()`.