### PR TITLE
Only import distro on Linux systems

### DIFF
--- a/automatic_tool_installation.py
+++ b/automatic_tool_installation.py
@@ -5,7 +5,6 @@ Functions related to the automatic installation of dependencies.
 import inspect
 import os
 import platform
-import distro
 import shutil
 import subprocess
 import sys
@@ -23,6 +22,7 @@ def detect_user_os():
     """
     system = platform.system()
     if system == 'Linux':
+        import distro
         detected_distro = distro.linux_distribution(full_distribution_name=False)
         detected_os = detected_distro[0]
     else:


### PR DESCRIPTION
This prevents an error on OSX, allowing the program to run.

```
  File "/Users/dnb/Desktop/code/clusterdash/minocore/softwipe/automatic_tool_installation.py", line 8, in <module>
    import distro
  File "/Users/dnb/miniconda3/lib/python3.7/site-packages/distro.py", line 42, in <module>
    raise ImportError('Unsupported platform: {0}'.format(sys.platform))
ImportError: Unsupported platform: darwin
```

